### PR TITLE
feat: add dropUniqueIndices function (helper function for migrat…

### DIFF
--- a/packages/history/README.md
+++ b/packages/history/README.md
@@ -103,6 +103,8 @@ await testEntity.remove();
 
 ## Advanced
 
+### Hooks
+
 You can hook before/after insert/update/remove history.
 
 ```ts
@@ -142,6 +144,31 @@ class TestHistoryEntitySubscriber extends HistoryEntitySubscriber<TestEntity, Te
   }
 
   public afterRemoveHistory(history: HistoryEntityType, entity: Readonly<EntityType>): void | Promise<void> {}
+}
+```
+
+### Drop unique indices
+
+The history table stores multiple entities with the same content, so it won't work well if there is a yunique index. You will need to drop the all unique indices.
+So I prepared a helper function for migration.
+
+```ts
+export class DropAllUniqueOfTestHistoryEntity1625470736630 {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await dropUniqueIndices(queryRunner, TestHistoryEntity /* "test_history_entity" */);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {}
+}
+```
+
+If you want to regenerate the index with the unique flag removed, please set keepIndex to true.
+
+```ts
+export class DropAllUniqueOfTestHistoryEntity1625470736630 {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await dropUniqueIndices(queryRunner, "test_history_entity", true);
+  }
 }
 ```
 

--- a/packages/history/README.md
+++ b/packages/history/README.md
@@ -149,7 +149,7 @@ class TestHistoryEntitySubscriber extends HistoryEntitySubscriber<TestEntity, Te
 
 ### Drop unique indices
 
-The history table stores multiple entities with the same content, so it won't work well if there is a yunique index. You will need to drop the all unique indices.
+The history table stores multiple entities with the same content, so it won't work well if there is a unique index. You will need to drop the all unique indices.
 So I prepared a helper function for migration.
 
 ```ts

--- a/packages/history/src/history-entity.spec-e2e.ts
+++ b/packages/history/src/history-entity.spec-e2e.ts
@@ -16,8 +16,8 @@ import {
 import { ulid } from "ulid";
 import { HistoryActionType } from "./history-action.enum";
 import { HistoryActionColumn, HistoryEntityInterface, HistoryOriginalIdColumn } from "./history-entity";
+import { dropUniqueIndices } from "./history-migration";
 import { HistoryEntitySubscriber } from "./history-subscriber";
-import { removeAllUniqueIndices } from "./history-migration";
 
 describe("e2e test (basic)", () => {
   @Entity()
@@ -706,6 +706,17 @@ describe("e2e test (custom property)", () => {
 describe("e2e test (remove unique index)", () => {
   @Entity()
   @Unique(["uniqueId4"])
+  @Index("test", ["uniqueId1", "uniqueId2"], { unique: true })
+  @Index(
+    () => {
+      return {
+        uniqueId1: 3,
+        uniqueId2: 2,
+        uniqueId3: 1,
+      };
+    },
+    { unique: true },
+  )
   class TestEntity extends BaseEntity {
     @PrimaryGeneratedColumn()
     public id!: number;
@@ -760,7 +771,7 @@ describe("e2e test (remove unique index)", () => {
       migrations: [
         class RemoveAllUniqueOfTestHistoryEntity1625470736630 {
           async up(queryRunner: QueryRunner): Promise<void> {
-            await removeAllUniqueIndices(queryRunner, TestHistoryEntity /* "test_history_entity" */);
+            await dropUniqueIndices(queryRunner, TestHistoryEntity /* "test_history_entity" */);
           }
         },
       ],

--- a/packages/history/src/history-entity.spec-e2e.ts
+++ b/packages/history/src/history-entity.spec-e2e.ts
@@ -6,14 +6,18 @@ import {
   EventSubscriber,
   getConnection,
   getRepository,
+  Index,
   JoinTable,
   ManyToMany,
   PrimaryGeneratedColumn,
+  QueryRunner,
+  Unique,
 } from "typeorm";
 import { ulid } from "ulid";
 import { HistoryActionType } from "./history-action.enum";
 import { HistoryActionColumn, HistoryEntityInterface, HistoryOriginalIdColumn } from "./history-entity";
 import { HistoryEntitySubscriber } from "./history-subscriber";
+import { removeAllUniqueIndices } from "./history-migration";
 
 describe("e2e test (basic)", () => {
   @Entity()
@@ -697,4 +701,88 @@ describe("e2e test (custom property)", () => {
 
     afterEach(() => getConnection().close());
   });
+});
+
+describe("e2e test (remove unique index)", () => {
+  @Entity()
+  @Unique(["uniqueId4"])
+  class TestEntity extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    public id!: number;
+
+    @Column()
+    public test!: string;
+
+    @Column({ unique: true })
+    public uniqueId1!: number;
+
+    @Column()
+    @Index({ unique: true })
+    public uniqueId2!: number;
+
+    @Column()
+    @Unique(["uniqueId3"])
+    public uniqueId3!: number;
+
+    @Column()
+    public uniqueId4!: number;
+  }
+
+  @Entity()
+  class TestHistoryEntity extends TestEntity {
+    @HistoryOriginalIdColumn()
+    public originalID!: number;
+
+    @HistoryActionColumn()
+    public action!: HistoryActionType;
+
+    @PrimaryGeneratedColumn()
+    public id!: number;
+  }
+
+  @EventSubscriber()
+  class TestHistoryEntitySubscriber extends HistoryEntitySubscriber<TestEntity, TestHistoryEntity> {
+    public entity = TestEntity;
+    public historyEntity = TestHistoryEntity;
+  }
+
+  beforeEach(async () => {
+    const connection = await createConnection({
+      database: "test",
+      dropSchema: true,
+      entities: [TestEntity, TestHistoryEntity],
+      host: process.env.DB_HOST || "localhost",
+      password: "root",
+      subscribers: [TestHistoryEntitySubscriber],
+      synchronize: true,
+      type: (process.env.DB_TYPE || "mysql") as any,
+      username: "root",
+      migrations: [
+        class RemoveAllUniqueOfTestHistoryEntity1625470736630 {
+          async up(queryRunner: QueryRunner): Promise<void> {
+            await removeAllUniqueIndices(queryRunner, TestHistoryEntity /* "test_history_entity" */);
+          }
+        },
+      ],
+      migrationsRun: true,
+    });
+    expect(connection).toBeDefined();
+    expect(connection.isConnected).toBeTruthy();
+  });
+
+  it("create history", async () => {
+    const testEntity = await TestEntity.create({
+      test: "test",
+      uniqueId1: 1,
+      uniqueId2: 2,
+      uniqueId3: 3,
+      uniqueId4: 4,
+    }).save();
+
+    testEntity.test = "updated";
+
+    await testEntity.save();
+  });
+
+  afterEach(() => getConnection().close());
 });

--- a/packages/history/src/history-migration.ts
+++ b/packages/history/src/history-migration.ts
@@ -1,0 +1,17 @@
+import { EntityTarget, QueryRunner } from "typeorm";
+
+export async function removeAllUniqueIndices(queryRunner: QueryRunner, target: EntityTarget<any>): Promise<void> {
+  const metadata = queryRunner.connection.getMetadata(target);
+
+  if (!metadata) {
+    throw Error(`metadata not found`);
+  }
+
+  for (const index of metadata.indices) {
+    if (!index.isUnique) {
+      continue;
+    }
+
+    await queryRunner.dropIndex(metadata.tableName, index.name);
+  }
+}

--- a/packages/history/src/history-migration.ts
+++ b/packages/history/src/history-migration.ts
@@ -1,6 +1,20 @@
-import { EntityTarget, QueryRunner } from "typeorm";
+import { EntityTarget, QueryRunner, TableIndex } from "typeorm";
 
-export async function removeAllUniqueIndices(queryRunner: QueryRunner, target: EntityTarget<any>): Promise<void> {
+/**
+ * Helper function for drop unique indices for history entity.
+ * The default is to drop the all unique indices.
+ * If you want to regenerate the index with the unique flag removed, please set keepIndex to true.
+ *
+ * @param {QueryRunner} queryRunner
+ * @param {EntityTarget<any>} target
+ * @param {boolean} [keepIndex=false] If false, drop the index. If true, regenerate the index with the unique flag removed.
+ * @return {*}  {Promise<void>}
+ */
+export async function dropUniqueIndices(
+  queryRunner: QueryRunner,
+  target: EntityTarget<any>,
+  keepIndex = false,
+): Promise<void> {
   const metadata = queryRunner.connection.getMetadata(target);
 
   if (!metadata) {
@@ -13,5 +27,24 @@ export async function removeAllUniqueIndices(queryRunner: QueryRunner, target: E
     }
 
     await queryRunner.dropIndex(metadata.tableName, index.name);
+
+    if (keepIndex) {
+      const columnNames = Object.entries(index.columnNamesWithOrderingMap)
+        .sort(([, a], [, b]) => a - b)
+        .map((x) => x[0]);
+
+      await queryRunner.createIndex(
+        metadata.tableName,
+        new TableIndex({
+          columnNames,
+          isUnique: false,
+          isSpatial: index.isSpatial,
+          isFulltext: index.isFulltext,
+          name: index.name,
+          parser: index.parser,
+          where: index.where,
+        }),
+      );
+    }
   }
 }


### PR DESCRIPTION
```ts
export class DropAllUniqueOfTestHistoryEntity1625470736630 {
  async up(queryRunner: QueryRunner): Promise<void> {
    await dropUniqueIndices(queryRunner, TestHistoryEntity /* "test_history_entity" */);
  }
};
```

If you want to regenerate the index with the unique flag removed, please set keepIndex to true.

```ts
export class DropAllUniqueOfTestHistoryEntity1625470736630 {
  async up(queryRunner: QueryRunner): Promise<void> {
    await dropUniqueIndices(queryRunner, TestHistoryEntity /* "test_history_entity" */, true);
  }
};
```