### PR TITLE
feat: improve HistoryEntityInterface

### DIFF
--- a/packages/history/README.md
+++ b/packages/history/README.md
@@ -36,7 +36,7 @@ You need to add the same column properties as `TestEntity`.
 
 ```ts
 @Entity()
-class TestHistoryEntity extends BaseEntity implements HistoryEntityInterface {
+class TestHistoryEntity extends BaseEntity implements HistoryEntityInterface<TestEntity> {
   // id is a property that holds the id of the TestHistoryEntity.
   @PrimaryGeneratedColumn()
   public id!: number;
@@ -57,7 +57,7 @@ Note: Starting with version 0.5.0, column names can be defined freely.
 
 ```ts
 @Entity()
-class TestHistoryEntity extends BaseEntity implements HistoryEntityInterface {
+class TestHistoryEntity extends BaseEntity implements HistoryEntityInterface<TestEntity> {
   @PrimaryGeneratedColumn()
   public id!: number;
 

--- a/packages/history/src/e2e-tests/basic.spec-e2e.ts
+++ b/packages/history/src/e2e-tests/basic.spec-e2e.ts
@@ -15,7 +15,7 @@ class TestEntity extends BaseEntity {
 }
 
 @Entity()
-class TestHistoryEntity extends BaseEntity implements HistoryEntityInterface {
+class TestHistoryEntity extends BaseEntity implements HistoryEntityInterface<TestEntity> {
   @PrimaryGeneratedColumn()
   public id!: number;
 
@@ -52,7 +52,7 @@ class TestEntity2 extends BaseEntity {
 }
 
 @Entity()
-class TestHistoryEntity2 extends BaseEntity implements HistoryEntityInterface {
+class TestHistoryEntity2 extends BaseEntity implements HistoryEntityInterface<TestEntity2> {
   @PrimaryGeneratedColumn()
   public id!: number;
 

--- a/packages/history/src/history-entity.ts
+++ b/packages/history/src/history-entity.ts
@@ -1,4 +1,4 @@
-import { Column, ColumnOptions } from "typeorm";
+import { BaseEntity, Column, ColumnOptions } from "typeorm";
 import { TYPEORM_HELPER_HISTORY_ACTION_TYPE, TYPEORM_HELPER_HISTORY_ORIGINAL_ID } from "./constants";
 import { HistoryActionType } from "./history-action.enum";
 
@@ -27,9 +27,10 @@ export function HistoryOriginalIdColumn(column?: ColumnOptions): PropertyDecorat
   };
 }
 
-export interface HistoryEntityInterface {
+export type HistoryEntityInterface<T = any> = {
   id: number | string;
   originalID: number | string;
-
   action: HistoryActionType;
-}
+} & T extends BaseEntity
+  ? Omit<T, keyof BaseEntity>
+  : T;


### PR DESCRIPTION
- https://github.com/anchan828/typeorm-helpers/issues/791

By setting the HistoryEntityInterface to Generic type, it is easier to create/manage History entities.